### PR TITLE
Configure CustomResource dynamically via outside of CFN bridge python class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 MANIFEST
 aws-cfn-resource-bridge-*.tar.gz
 dist/
+build/

--- a/aws/cfn/bridge/__init__.py
+++ b/aws/cfn/bridge/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #==============================================================================
 __author__ = 'aws'
-__version__ = '0.2'
+__version__ = '0.2.1'
 
 import logging.config
 import os.path

--- a/aws/cfn/bridge/__init__.py
+++ b/aws/cfn/bridge/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #==============================================================================
 __author__ = 'aws'
-__version__ = '0.2.1'
+__version__ = '0.3'
 
 import logging.config
 import os.path

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -1,0 +1,57 @@
+import unittest2 as unittest
+
+from aws.cfn.bridge.resources import CustomResource
+
+
+class CfnBridgeConfigProvider(object):
+
+    def get_option(self):
+        return {
+            'queue_url': 'https://queue.us-east-1.amazonaws.com',
+            'default_action': 'action-default'
+        }
+
+
+class TestConfigProvider(unittest.TestCase):
+
+    def test_override_custome_resource_by_config_provider(self):
+        options = {
+            'config_provider': (
+                'test_config_provider.CfnBridgeConfigProvider.get_option')
+        }
+        resource = CustomResource('name', 'file', options)
+        self.assertEqual(
+            resource.queue_url, 'https://queue.us-east-1.amazonaws.com')
+
+    def test_override_custome_resource_with_incorrect_module(self):
+        options = {
+            'config_provider': 'XXXXXX.CfnBridgeConfigProvider.get_option',
+        }
+        with self.assertRaises(ValueError):
+            CustomResource('name', 'file', options)
+
+    def test_override_custome_resource_with_incorrect_class(self):
+        options = {
+            'config_provider': 'test_config_provider.XXXXXX.get_option',
+        }
+        with self.assertRaises(ValueError):
+            CustomResource('name', 'file', options)
+
+    def test_override_custome_resource_with_incorrect_fnunc(self):
+        options = {
+            'config_provider': (
+                'test_config_provider.CfnBridgeConfigProvider.XXXXXX')
+        }
+        with self.assertRaises(ValueError):
+            CustomResource('name', 'file', options)
+
+    def test_override_custome_resource_not_enough_params(self):
+        options = {
+            'config_provider': 'XXXXXX.XXXXXX',
+        }
+        with self.assertRaises(ValueError):
+            CustomResource('name', 'file', options)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -3,7 +3,7 @@ import unittest2 as unittest
 from aws.cfn.bridge.resources import CustomResource
 
 
-class CfnBridgeConfigProvider(object):
+class MockCfnBridgeConfigProvider(object):
 
     def get_options(self):
         return {
@@ -12,13 +12,13 @@ class CfnBridgeConfigProvider(object):
         }
 
 
-class RaiseCfnBridgeConfigProvider(object):
+class MockCfnBridgeConfigProviderRaise(object):
 
     def get_options(self):
         raise Exception('Raise')
 
 
-class NotDefiendCfnBridgeConfigProvider(object):
+class MockCfnBridgeConfigProviderNotDefiend(object):
     pass
 
 
@@ -27,7 +27,7 @@ class TestConfigProvider(unittest.TestCase):
     def test_override_custome_resource_by_config_provider(self):
         options = {
             'config_provider': (
-                'test_config_provider.CfnBridgeConfigProvider')
+                'test_config_provider.MockCfnBridgeConfigProvider')
         }
         resource = CustomResource('name', 'file', options)
         self.assertEqual(
@@ -35,7 +35,7 @@ class TestConfigProvider(unittest.TestCase):
 
     def test_override_custome_resource_with_incorrect_module(self):
         options = {
-            'config_provider': 'XXXXXX.CfnBridgeConfigProvider.get_option',
+            'config_provider': 'XXXXXX.MockCfnBridgeConfigProvider.get_option',
         }
         with self.assertRaises(ValueError):
             CustomResource('name', 'file', options)
@@ -43,7 +43,7 @@ class TestConfigProvider(unittest.TestCase):
     def test_override_custome_resource_get_option_not_defiend(self):
         options = {
             'config_provider': (
-                'test_config_provider.NotDefinedCfnBridgeConfigProvider')
+                'test_config_provider.MockCfnBridgeConfigProviderNotDefined')
         }
         with self.assertRaises(ValueError):
             CustomResource('name', 'file', options)
@@ -51,7 +51,7 @@ class TestConfigProvider(unittest.TestCase):
     def test_override_custome_resource_get_option_raise(self):
         options = {
             'config_provider': (
-                'test_config_provider.RaiseCfnBridgeConfigProvider')
+                'test_config_provider.MockCfnBridgeConfigProviderRaise')
         }
         with self.assertRaises(Exception):
             CustomResource('name', 'file', options)

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -5,11 +5,21 @@ from aws.cfn.bridge.resources import CustomResource
 
 class CfnBridgeConfigProvider(object):
 
-    def get_option(self):
+    def get_options(self):
         return {
             'queue_url': 'https://queue.us-east-1.amazonaws.com',
             'default_action': 'action-default'
         }
+
+
+class RaiseCfnBridgeConfigProvider(object):
+
+    def get_options(self):
+        raise Exception('Raise')
+
+
+class NotDefiendCfnBridgeConfigProvider(object):
+    pass
 
 
 class TestConfigProvider(unittest.TestCase):
@@ -17,7 +27,7 @@ class TestConfigProvider(unittest.TestCase):
     def test_override_custome_resource_by_config_provider(self):
         options = {
             'config_provider': (
-                'test_config_provider.CfnBridgeConfigProvider.get_option')
+                'test_config_provider.CfnBridgeConfigProvider')
         }
         resource = CustomResource('name', 'file', options)
         self.assertEqual(
@@ -30,19 +40,20 @@ class TestConfigProvider(unittest.TestCase):
         with self.assertRaises(ValueError):
             CustomResource('name', 'file', options)
 
-    def test_override_custome_resource_with_incorrect_class(self):
+    def test_override_custome_resource_get_option_not_defiend(self):
         options = {
-            'config_provider': 'test_config_provider.XXXXXX.get_option',
+            'config_provider': (
+                'test_config_provider.NotDefinedCfnBridgeConfigProvider')
         }
         with self.assertRaises(ValueError):
             CustomResource('name', 'file', options)
 
-    def test_override_custome_resource_with_incorrect_fnunc(self):
+    def test_override_custome_resource_get_option_raise(self):
         options = {
             'config_provider': (
-                'test_config_provider.CfnBridgeConfigProvider.XXXXXX')
+                'test_config_provider.RaiseCfnBridgeConfigProvider')
         }
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             CustomResource('name', 'file', options)
 
     def test_override_custome_resource_not_enough_params(self):

--- a/tests/unit/test_custom_resources.py
+++ b/tests/unit/test_custom_resources.py
@@ -18,7 +18,6 @@ from tests import unittest, expect_error
 
 from aws.cfn.bridge.resources import CustomResource
 
-
 class TestCustomResource(unittest.TestCase):
     def setUp(self):
         self.options = {

--- a/tests/unit/test_custom_resources.py
+++ b/tests/unit/test_custom_resources.py
@@ -18,6 +18,7 @@ from tests import unittest, expect_error
 
 from aws.cfn.bridge.resources import CustomResource
 
+
 class TestCustomResource(unittest.TestCase):
     def setUp(self):
         self.options = {


### PR DESCRIPTION
- Add option for importing outside of python class that returns config params,
  and override CustomResoruce attributes dynamically instead of loading
  config file. For example, outside of python class is able to retive config
  params via network such as AWS dynamodb.

```
#> cat /etc/cfn/cfn-resource-bridge.conf

[cfn_client]
resource_type=Custom::CfnCustom
config_provider=example.com.config_provider.CfnBridgeConfigProvider.get_options


#> cat /Library/Python/2.7/site-packages/eaxmple/com/config_provider.py

class CfnBridgeConfigProvider(object):

    def get_options(self):
        queue_url = self.get_queue_url_from_aws_dynamodb()
        return {
            'queue_url': queue_url,
            'default_action': 'action-default'
        }
```
